### PR TITLE
Allow users to select an endpoint, and cache their choice

### DIFF
--- a/.template.ok
+++ b/.template.ok
@@ -1,0 +1,16 @@
+{
+  "name": "Program 08",
+  "endpoint": "<#endpoint#>/project08",
+  "src": [
+    "P8.ipynb",
+    "imgfilter.py"
+  ],
+  "tests": {
+      "tests/q*.py": "ok_test"
+  },
+  "protocols": [
+      "file_contents",
+      "grading",
+      "backup"
+  ]
+}

--- a/cs1/notebooks.py
+++ b/cs1/notebooks.py
@@ -16,6 +16,17 @@ from IPython.display import display, Markdown, Latex
 _ok = None
 
 # Configs for rewriting ok files.
+# If an ok file is not found during at attempted load, a template can be
+# used to generate one. This allows for different endpoints for the same
+# general ok config without modifying the okpy library.
+# The user is presented with the option of choosing a professor (and associated
+# endpoint), which are loaded either from a config file in the filesystem,
+# or from a url.
+# Endpoint options should be a JSON-encoded map. e.g.,
+# {
+#  "Lang": "rhodes/comp141-01/sp21",
+#  "Kirlin": "rhodes/comp141-02/sp21"
+# }
 _OPTIONS_URL = 'https://storage.googleapis.com/comp141-public/options.json'
 _OPTIONS_FNAME = '.options'
 _TEMPLATE_FNAME = '.template.ok'

--- a/cs1/notebooks.py
+++ b/cs1/notebooks.py
@@ -71,7 +71,7 @@ def _rewrite_template(fname, endpoint):
     out.write(ok_contents)
     out.close()
 
-def _validate_or_create(fname):
+def _validate_or_create(fname, ignore_cache):
     """Validates the existence of .ok file, or creates it.
     
     First checks whether the file exists. If so, nothing is done.
@@ -80,10 +80,10 @@ def _validate_or_create(fname):
     If the endpoint does not exist, the user is prompted to chose from a list
     of endpoints, and the chosen endpoint is cached before the file is written.
     """
-    if os.path.isfile(fname):
+    if os.path.isfile(fname) and not ignore_cache:
         return
     ep_file = os.path.join(os.path.expanduser("~"), _EP_FNAME)
-    if os.path.isfile(ep_file):
+    if os.path.isfile(ep_file) and not ignore_cache:
         ep = open(ep_file).read()
     else:
         opts = _get_endpoints()
@@ -105,26 +105,27 @@ def _maybe_login(okfile):
     """Authenticate to OK, if necessary."""
     global _ok
     if not _ok:
-        _force_login(okfile)
+        _force_login(okfile, ignore_cache=False)
         
-def _force_login(okfile):
+def _force_login(okfile, ignore_cache):
     """Authenticate to OK, even if we are already logged in."""
     global _ok
     _ok = None
-    _validate_or_create(okfile)
+    _validate_or_create(okfile, ignore_cache)
     _ok = Notebook(okfile)
     _ok.auth(inline=True)
 
-def ok_login(okfile):
+def ok_login(okfile, ignore_cache=False):
     """Authenticate to the OK submission website.
     This is a wrapper around creating a Notebook object and calling auth().
     Will re-authenticate even if we are already logged in.
     
     okfile: the .ok file that describes the OK assignment we are using.
+    ignore_cache: whether to ignore .ok files and endpoint selection.
     """
     
     global _ok
-    _force_login(okfile)
+    _force_login(okfile, ignore_cache)
     
 def ok_runtests(okfile, question):
     """Run test cases and grade them using OK.

--- a/scratch.ipynb
+++ b/scratch.ipynb
@@ -1,0 +1,95 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "active-compression",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from cs1.notebooks import *\n",
+    "ok_login('p8.ok')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "incomplete-aside",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "os.remove('p8.ok')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "suitable-kruger",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ep_file = os.path.join(os.path.expanduser(\"~\"), \".141_endpoint\")\n",
+    "os.remove(ep_file)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "western-agenda",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.6"
+  },
+  "varInspector": {
+   "cols": {
+    "lenName": 16,
+    "lenType": 16,
+    "lenVar": 40
+   },
+   "kernels_config": {
+    "python": {
+     "delete_cmd_postfix": "",
+     "delete_cmd_prefix": "del ",
+     "library": "var_list.py",
+     "varRefreshCmd": "print(var_dic_list())"
+    },
+    "r": {
+     "delete_cmd_postfix": ") ",
+     "delete_cmd_prefix": "rm(",
+     "library": "var_list.r",
+     "varRefreshCmd": "cat(var_dic_list()) "
+    }
+   },
+   "types_to_exclude": [
+    "module",
+    "function",
+    "builtin_function_or_method",
+    "instance",
+    "_Feature"
+   ],
+   "window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
When attempting to load a `.ok` file:
* If the file exists, load it.
* Otherwise, check for the existence of a file containing a cached okpy endpoint choice in the user's home directory.
* If this exists, open a template `.ok` file (to be distributed alongside the assignment notebook), and replace any endpoint placeholder with the cached endpoint.
* If the cached endpoint does not exist, load a list of endpoint options and allow the user to choose their class.

Sample interaction:
```
> from cs1.notebooks import *
> ok_login('p8.ok')
Select a class:
	0. Lang
	1. Kirlin
0
=====================================================================
Assignment: Program 08
OK, version v1.18.1
=====================================================================

Successfully logged in as langma@gmail.com
```

Subsequent loads:
```
> from cs1.notebooks import *
> ok_login('p8.ok')

=====================================================================
Assignment: Program 08
OK, version v1.18.1
=====================================================================

Successfully logged in as langma@gmail.com
```

PR contains an example notebook and template, which will be removed.

## Update 5/19:
* Added option to ignore `ok` files and cached endpoints, forcing a re-selection of endpoint.
* Allows students to fix errors with `ok_login('...', ignore_cache=True)`.
* Alternative approach would be to have an API surface that deletes the cached endpoint file. That approach would also have to 1) look for a `.template` file and 2) delete the previously-written `ok` file if one exists, as well.

cc @CatieWelsh @betswms 
