### PR TITLE
Rate limit calls to frontend graphics library

### DIFF
--- a/cs1/graphics.py
+++ b/cs1/graphics.py
@@ -321,7 +321,7 @@ def draw_string(message, x, y, textSize):
 
 @rate_limit
 def save_canvas_as_image(filename):
-  """Saves the image to the supplied filename, which must end in .ps or .eps"""
+  """Saves the image to the supplied filename, which must end in .png"""
   global _canvas
   _check()
   _canvas.to_file(filename)

--- a/cs1/graphics.py
+++ b/cs1/graphics.py
@@ -7,6 +7,7 @@ from time import time, sleep
 from threading import Lock
 from uuid import uuid1
 
+import functools
 import os
 
 from jupyter_ui_poll import ui_events
@@ -17,19 +18,84 @@ import IPython.display as disp
 
 from ipycanvas import MultiCanvas
 
+# If true, print/log/display debug information.
+# False should be the distributed default.
+_DEBUG = False
+
+# Rate limiting for drawing calls
+
+def _bound(v, s, l):
+  return min(max(v, s), l)
+
+def _now_millis():
+  return round(time() * 1000)
+
+class Limiter:
+  """Rate limiter."""
+  def __init__(self, limit=1000, period=1000):
+    """Initialize limiter.
+
+    Args:
+        limit: number of allowed queries per period.
+        period: time in milliseconds.
+    """
+    self._limit = limit
+    self._rate = limit / period # float rate per millisecond
+    self._last = 0 # timestamp of last queries (in millis)
+    self._count = limit # remaining queries
+
+  def _allot(self):
+    """Allot queries for elapsed time."""
+    now = _now_millis()
+    since = now - self._last
+    self._last = now
+    allot = self._rate * since
+    self._count += allot
+    self._count = _bound(self._count, 0, self._limit)
+
+  def query(self):
+    """Returns true iff the query should be permitted."""
+    self._allot()
+    if self._count > 1:
+      self._count -= 1
+      return True
+    return False
+
+_limiter = Limiter()
+_BACKOFF_SLEEP_SECS = 0.2
+_limited_count = 0
+
+def rate_limit(f):
+  """Decorator to rate limit f."""
+  @functools.wraps(f)
+  def maybe_delay(*args, **kwargs):
+    global _limiter, _limited_count
+    if not _limiter.query():
+      if _DEBUG:
+        print('rate limited...')
+      _limited_count += 1
+      if _limited_count > 10:
+        _limited_count = 0
+        raise RuntimeError("Too many graphics calls too frequently! Do you have an infinite loop?")
+      sleep(_BACKOFF_SLEEP_SECS)
+    return f(*args, **kwargs)
+  return maybe_delay
+
+# Canvas; foreground and background layers.
 _canvas = None
 _fg = None
 _bg = None
 
+# ipyevents object, coordinates of last click (x, y), and timestamp of last click.
 _events = None
-_click_coords = None
+_click_coords = (None, None)
 _last_mouse_ts = None
 
+# Widget layout containing canvas.
 _out = None
 
+# Whether to draw the canvas border.
 _DRAW_BORDER = True
-
-# Global functionality
 
 def _check():
   global _canvas
@@ -44,6 +110,7 @@ def _handle_event(event):
   _click_coords = (event['offsetX'], event['offsetY'])
   _last_mouse_ts = time()
 
+@rate_limit
 def open_canvas(width, height):
   """Creates a window for painting of a given width and height."""
   global _canvas, _bg, _fg, _events, _out
@@ -69,6 +136,7 @@ def open_canvas(width, height):
     draw_rect(0, 0, width, height)
 
 def wait_for_mouse_click():
+  """Waits until the mouse has been clicked."""
   global _last_mouse_ts
   now = time()
   with ui_events() as ui_poll:
@@ -79,29 +147,31 @@ def wait_for_mouse_click():
       sleep(0.05)
 
 def get_mouse_click_x():
+  """Returns the x coordinate of the last mouse click."""
   return _click_coords[0]
 
 def get_mouse_click_y():
+  """Returns the y coordinate of the last mouse click."""
   return _click_coords[1]
 
 def get_canvas():
+  """Returns the canvas object."""
   global _canvas
   return _canvas
 
+@rate_limit
 def clear_canvas():
   """Clears the canvas of all shapes and text."""
   _check()
   global _fg
   _fg.clear()
-  
-# Drawing functions
 
 def set_line_thickness(thickness):
   """Sets the canvas painting line width to the value given."""
   global _fg
   _check()
   _fg.line_width = thickness
-  
+
 def set_color(color):
   """Sets the current painting color."""
   global _fg
@@ -123,18 +193,21 @@ def set_color_rgb(r, g, b):
   _fg.stroke_style = color
   _fg.fill_style = color
 
+@rate_limit
 def draw_circle(centerx, centery, radius):
   """Draws a circle on the canvas."""
   global _fg
   _check()
   _fg.stroke_circle(centerx, centery, radius)
 
+@rate_limit
 def draw_filled_circle(centerx, centery, radius):
   """Draws a filled circle on the canvas."""
   global _fg
   _check()
   _fg.fill_circle(centerx, centery, radius)
 
+@rate_limit
 def draw_oval(centerx, centery, radiusx, radiusy):
   """Draws an oval on the canvas."""
   global _fg
@@ -144,6 +217,7 @@ def draw_oval(centerx, centery, radiusx, radiusy):
   _fg.stroke()
   _fg.close_path()
 
+@rate_limit
 def draw_filled_oval(centerx, centery, radiusx, radiusy):
   """Draws a filled oval on the canvas."""
   global _fg
@@ -154,12 +228,14 @@ def draw_filled_oval(centerx, centery, radiusx, radiusy):
   _fg.stroke()
   _fg.close_path()
 
+@rate_limit
 def draw_line(x1, y1, x2, y2):
   """Draws a line on the canvas from (x1, y1) to (x2, y2)."""
   global _fg
   _check()
   _fg.stroke_line(x1, y1, x2, y2)
         
+@rate_limit
 def draw_rect(x, y, width, height):
   """Draws a rectangle on the canvas. Upper left corner at (x, y), width and height as given."""
   global _fg
@@ -169,6 +245,7 @@ def draw_rect(x, y, width, height):
   _fg.stroke()
   _fg.close_path()
 
+@rate_limit
 def draw_filled_rect(x, y, width, height):
   """Draws a filled rectangle on the canvas. Upper left corner at (x, y), width and height as given."""
   global _fg
@@ -178,7 +255,8 @@ def draw_filled_rect(x, y, width, height):
   _fg.stroke()
   _fg.fill()
   _fg.close_path()
-  
+
+@rate_limit
 def draw_polyline(*points):
   """Draws a polyline on the canvas.  The points of the polyline are (x,y) pairs
   specified as one big list.  E.g.: draw_polyline(10, 10, 20, 20, 30, 40) draws a
@@ -187,6 +265,7 @@ def draw_polyline(*points):
   _check()
   _fg.stroke_lines(list(points))
 
+@rate_limit
 def draw_polygon(*points):
   """Draws a polygon on the canvas.  The points of the polygon are (x,y) pairs
   specified as one big list.  E.g.: draw_polygon(10, 10, 20, 20, 30, 40) draws a
@@ -195,6 +274,7 @@ def draw_polygon(*points):
   _check()
   _fg.stroke_polygon(list(points))
 
+@rate_limit
 def draw_filled_polygon(*points):
   """Draws a filled polygon on the canvas.  The points of the polygon are (x,y) pairs
   specified as one big list.  E.g.: draw_polygon(10, 10, 20, 20, 30, 40) draws a
@@ -218,6 +298,7 @@ def set_background_color_rgb(r, g, b):
   _bg.fill_style = _rgb2str(r, g, b)
   _bg.fill_rect(0, 0, _canvas.width, _canvas.height)
   
+@rate_limit
 def draw_string(message, x, y, textSize):
   """Draws the message at the given location [(x, y) will be where the
   midpoint of the string ends up] with the given font size in points."""
@@ -226,13 +307,14 @@ def draw_string(message, x, y, textSize):
   _fg.font = '%dpx serif' % textSize
   _fg.fill_text(message, x, y)
 
+@rate_limit
 def save_canvas_as_image(filename):
   """Saves the image to the supplied filename, which must end in .ps or .eps"""
   global _canvas
   _check()
   _canvas.to_file(filename)
-  
 
+@rate_limit
 def checkpoint_canvas():
   """Displays a checkpoint of the canvas as the output to the current cell."""
   global _canvas

--- a/scratch.ipynb
+++ b/scratch.ipynb
@@ -3,40 +3,34 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "active-compression",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from cs1.notebooks import *\n",
-    "ok_login('p8.ok')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "incomplete-aside",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "os.remove('p8.ok')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "suitable-kruger",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ep_file = os.path.join(os.path.expanduser(\"~\"), \".141_endpoint\")\n",
-    "os.remove(ep_file)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "western-agenda",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2\n",
+    "from random import randint\n",
+    "from cs1.graphics import *\n",
+    "\n",
+    "open_canvas(200, 200)\n",
+    "for i in range(100_000_000):\n",
+    "    draw_circle(randint(0, 200), randint(0, 200), 5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9e07d9e2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('hi')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c2dda6d9",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -44,7 +38,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -58,7 +52,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.9.7"
   },
   "varInspector": {
    "cols": {


### PR DESCRIPTION
Rate limits calls to the frontend graphics library in order to prevent the UI from crashing.

Allows rate is 50 calls per 500ms. If this rate is hit, the caller is throttled with a 200ms sleep.

Fixes #11. Tested with the attached scratch notebook by letting it run for some time, then interrupting or restarting kernel, then running another cell.

FYI @walidabualafia @anesepark @msuperdock 